### PR TITLE
Fix communication backend path

### DIFF
--- a/examples/train_homogeneous_graph_basic.py
+++ b/examples/train_homogeneous_graph_basic.py
@@ -47,6 +47,8 @@ parser.add_argument(
 parser.add_argument('--ip-file', default='./ip_file', type=str,
                     help='File with ip-address. Worker 0 creates this file and all others read it ')
 
+parser.add_argument('--shared-file', default='./shared_file', type=str,
+                    help='Path to a file required by torch.dist for inter-process communication')
 
 parser.add_argument('--backend', default='nccl', type=str, choices=['ccl', 'nccl', 'mpi'],
                     help='Communication backend to use '
@@ -243,7 +245,7 @@ def run(args, rank, lock, barrier):
     master_ip_address = sar.nfs_ip_init(rank, args.ip_file)
     sar.initialize_comms(rank,
                          args.world_size, master_ip_address,
-                         args.backend)
+                         args.backend, args.shared_file, barrier)
 
     lock.acquire()
     print("Node {} Lock Acquired".format(rank))


### PR DESCRIPTION
Now user has to specify path to the shared file (by default it will be created in a working directory under name "shared_file"). Before initializing communication, file is deleted if it already exists, because torch does not guarantee to clear it after training.