### PR TITLE
Backward compatibility

### DIFF
--- a/examples/SIGN/train_sign_with_sar.py
+++ b/examples/SIGN/train_sign_with_sar.py
@@ -203,6 +203,7 @@ def main(args):
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
+    sar.start_comm_thread()
 
     data = prepare_data(device, args)
     (
@@ -275,7 +276,7 @@ if __name__ == "__main__":
                         help="File with ip-address. "
                              "Worker 0 creates this file and all others read it")
     parser.add_argument("--backend", type=str, default="ccl",
-                        choices=["ccl", "nccl", "mpi"],
+                        choices=["ccl", "nccl", "mpi", "gloo"],
                         help="Communication backend to use")
     parser.add_argument("--rank", type=int, default=0,
                         help="Rank of the current worker")

--- a/examples/correct_and_smooth.py
+++ b/examples/correct_and_smooth.py
@@ -369,6 +369,7 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
+    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_dist_appnp_with_sar.py
+++ b/examples/train_dist_appnp_with_sar.py
@@ -134,7 +134,8 @@ def main():
                          args.world_size,
                          master_ip_address,
                          args.backend)
-
+    sar.start_comm_thread()
+    
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(
         args.partitioning_json_file, args.rank, device)

--- a/examples/train_distdgl_with_sar_inference.py
+++ b/examples/train_distdgl_with_sar_inference.py
@@ -375,6 +375,7 @@ def main(args):
                          master_ip_address,
                          args.backend
                          )
+    sar.start_comm_thread()
 
     print(socket.gethostname(), "rank:", g.rank())
 

--- a/examples/train_heterogeneous_graph.py
+++ b/examples/train_heterogeneous_graph.py
@@ -116,6 +116,7 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
+    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_homogeneous_graph_advanced.py
+++ b/examples/train_homogeneous_graph_advanced.py
@@ -276,6 +276,7 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend, comm_device)
+    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_homogeneous_graph_basic_single-node.py
+++ b/examples/train_homogeneous_graph_basic_single-node.py
@@ -50,7 +50,7 @@ parser.add_argument('--ip-file', default='./ip_file', type=str,
 parser.add_argument('--shared-file', default='./shared_file', type=str,
                     help='Path to a file required by torch.dist for inter-process communication')
 
-parser.add_argument('--backend', default='nccl', type=str, choices=['ccl', 'nccl', 'mpi'],
+parser.add_argument('--backend', default='nccl', type=str, choices=['ccl', 'nccl', 'mpi', 'gloo'],
                     help='Communication backend to use '
                     )
 
@@ -245,7 +245,7 @@ def run(args, rank, lock, barrier):
     master_ip_address = sar.nfs_ip_init(rank, args.ip_file)
     sar.initialize_comms(rank,
                          args.world_size, master_ip_address,
-                         args.backend, args.shared_file, barrier)
+                         args.backend, shared_file=args.shared_file, barrier=barrier)
 
     lock.acquire()
     print("Node {} Lock Acquired".format(rank))

--- a/examples/train_homogeneous_sampling_basic.py
+++ b/examples/train_homogeneous_sampling_basic.py
@@ -152,6 +152,7 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
+    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/sar/comm.py
+++ b/sar/comm.py
@@ -130,9 +130,9 @@ def nfs_ip_init(_rank: int, ip_file: str) -> str:
 
 
 def initialize_comms(_rank: int, _world_size: int, master_ip_address: str,
-                     backend: str, shared_file: str = None, barrier: Barrier = None, 
-                     _comm_device: Optional[torch.device] = None,
-                     master_port_number: int = 12345):
+                     backend: str, _comm_device: Optional[torch.device] = None,
+                     master_port_number: int = 12345, shared_file: str = None,
+                     barrier: Barrier = None):
     """
     Initialize Pytorch's communication library
 
@@ -144,17 +144,15 @@ def initialize_comms(_rank: int, _world_size: int, master_ip_address: str,
     :type master_ip_address: str
     :param backend: Backend to use. Can be ccl, nccl, mpi or gloo
     :type backend: str
-    :param shared_file: Path to a file required by torch.dist for inter-process communication
-    :type shared_file: str
-    :param barrier: Barrier for synchronizing processes
-    :type barrier: Barrier
     :param _comm_device:  The device on which the tensors should be on in order to transmit them\
     through the backend. If not provided, the device is infered based on the backend type
     :type _comm_device: torch.device
     :param master_port_number:  The port number on the master
-    :type _comm_device: int
-
-
+    :type master_port_number: int
+    :param shared_file: Path to a file required by torch.dist for inter-process communication
+    :type shared_file: str
+    :param barrier: Barrier for synchronizing processes
+    :type barrier: Barrier
     """
     assert backend in ['ccl', 'nccl', 'mpi', 'gloo'],\
         'backend must be ccl, nccl, mpi or gloo'

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -23,6 +23,7 @@ def initialize_worker(rank, world_size, tmp_dir, backend="ccl"):
     ip_file = os.path.join(tmp_dir, 'ip_file')
     master_ip_address = sar.nfs_ip_init(rank, ip_file)
     sar.initialize_comms(rank, world_size, master_ip_address, backend)
+    sar.start_comm_thread()
 
 
 def get_random_graph():

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -46,6 +46,7 @@ def sar_process(mp_dict, rank, world_size, tmp_dir):
                              world_size,
                              master_ip_address,
                              'ccl')
+        sar.start_comm_thread()
 
         partition_data = sar.load_dgl_partition_data(
             part_file, rank, 'cpu')


### PR DESCRIPTION
- Added sar.start_comm_thread() to all of the example scripts and to pytests
- Added possibility to pass gloo as a backend parameter in example scripts

With these changes I was able to run all of the examples scripts and every pytest succeded.