### PR TITLE
Pytests for comm.py

### DIFF
--- a/sar/data_loading.py
+++ b/sar/data_loading.py
@@ -24,6 +24,154 @@ from torch import Tensor
 import dgl  # type: ignore
 from dgl.distributed.partition import load_partition  # type: ignore
 from .common_tuples import PartitionData, ShardEdgesAndFeatures
+import logging
+
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+logger.setLevel(logging.DEBUG)
+
+
+class PartitionDataManager:
+    """
+    Manages loading and saving data to disk, when SAR is running in single-node mode.
+    
+    :param idx: rank of the worker
+    :type idx: int
+    :param lock: lock is used to synchronize processes, so that we can be sure only one partition is\
+    loaded at the same time
+    :type lock: Lock
+    :param folder_name_prefix: prefix of the name of the folder where the data will be saved on the disk
+    :type folder_name_prefix: string
+    """
+    def __init__(self, idx, lock, folder_name_prefix="partition_rank_"):
+        self.idx = idx
+        self.lock = lock
+        self.folder_name = f"{folder_name_prefix}{idx}"
+        self._features = None
+        self._masks = None
+        self._labels = None
+        self._partition_data = None
+
+    @property
+    def partition_data(self):
+        if self._partition_data is None:
+            raise ValueError("partition_data not set")
+        return self._partition_data
+    
+    @partition_data.setter
+    def partition_data(self, data):
+        self._partition_data = data
+
+    @partition_data.deleter
+    def partition_data(self):
+        del self._partition_data
+
+    @property
+    def features(self):
+        # if self._features is None:
+        #    raise ValueError("features not set")
+        return self._features
+    
+    @features.setter
+    def features(self, feats):
+        self._features = feats
+
+    @features.deleter
+    def features(self):
+        del self._features
+        self._features = None
+
+    @property
+    def labels(self):
+        if self._labels is None:
+            raise ValueError("labels not set")
+        return self._labels
+    
+    @labels.setter
+    def labels(self, labels):
+        self._labels = labels
+    
+    @property
+    def masks(self):
+        if self._masks is None:
+            raise ValueError("masks not set")
+        return self._masks
+    
+    @masks.setter
+    def masks(self, masks):
+        self._masks = masks
+    
+    def precall_func(self):
+        self.save()
+        if isinstance(self.features, torch.Tensor): 
+            self.save_tensor(self.features, 'features')
+            del self.features
+        self.delete()
+        self.lock.release()
+        print("Node {} Lock Released".format(self.idx))
+
+    def callback_func(self, handle):    
+        handle.wait()
+        self.lock.acquire()
+        print("Node {} Lock Acquired".format(self.idx))
+        self.load()
+        features = self.load_tensor('features')
+        if features is not None:
+            self.features = features
+            
+    def save(self):
+        try:
+            if not os.path.exists(self.folder_name):
+                os.makedirs(self.folder_name)
+            if self._masks is not None:
+                torch.save(self._masks, os.path.join(self.folder_name, "masks.pt"))
+            if self._labels is not None:
+                torch.save(self._labels, os.path.join(self.folder_name, "labels.pt"))
+            if self._partition_data is not None:
+                torch.save(self._partition_data, os.path.join(self.folder_name, "partition_data.pt"))
+        except Exception as e:
+            logger.debug("_pause_process Exception: {}".format(e))
+            return False
+        return True
+
+    def save_tensor(self, tensor, tensor_name):
+        if not os.path.exists(self.folder_name):
+            os.makedirs(self.folder_name)
+        if tensor is not None:
+            torch.save(tensor, os.path.join(self.folder_name, tensor_name + ".pt"))
+
+    def delete(self):
+        if hasattr(self, '_masks'):
+            del self._masks
+        if hasattr(self, '_labels'):
+            del self._labels
+        if hasattr(self, '_partition_data'):
+            del self._partition_data
+
+    def load(self):
+        if not os.path.exists(self.folder_name):
+            raise FileNotFoundError("No partition data saved")
+        if os.path.exists(os.path.join(self.folder_name, "masks.pt")):
+            self._masks = torch.load(os.path.join(self.folder_name, "masks.pt"))
+        else:
+            print("masks not loaded, no file saved")
+        if os.path.exists(os.path.join(self.folder_name, "labels.pt")):
+            self._labels = torch.load(os.path.join(self.folder_name, "labels.pt"))
+        else:
+            print("labels not loaded, no file saved")
+        if os.path.exists(os.path.join(self.folder_name, "partition_data.pt")):
+            self._partition_data = torch.load(os.path.join(self.folder_name, "partition_data.pt"))
+        else:
+            print("partition_data not loaded, no file saved")
+
+    def load_tensor(self, tensor_name):
+        if not os.path.exists(self.folder_name):
+            raise FileNotFoundError("No partition data saved")
+        if os.path.exists(os.path.join(self.folder_name, tensor_name + ".pt")):
+            return torch.load(os.path.join(self.folder_name, tensor_name + ".pt"))
+        else: 
+            return None
 
 
 def suffix_key_lookup(feature_dict: Dict[str, Tensor], key: str,

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -8,9 +8,10 @@ import dgl
  
 
 
-def initialize_worker(rank, world_size, tmp_dir, backend="ccl"):
+def initialize_worker(rank, world_size, tmp_dir, backend="ccl", barrier=None):
     """
-    Boilerplate code for setting up connection between workers
+    Boilerplate code for setting up connection between workers. If barrier is passed
+    (not None) then code prepares workers to run in single-node mode.
     
     :param rank: Rank of the current machine
     :type rank: int
@@ -18,11 +19,20 @@ def initialize_worker(rank, world_size, tmp_dir, backend="ccl"):
     :type world_size: int
     :param tmp_dir: Path to the directory where ip file will be created
     :type tmp_dir: str
+    :param barrier: Barrier for synchronizing processes
+    :type barrier: Barrier
     """
     torch.seed()
     ip_file = os.path.join(tmp_dir, 'ip_file')
     master_ip_address = sar.nfs_ip_init(rank, ip_file)
-    sar.initialize_comms(rank, world_size, master_ip_address, backend)
+    
+    if barrier is None:
+        sar.initialize_comms(rank, world_size, master_ip_address, backend)
+    else:
+        shard_file = os.path.join(tmp_dir, 'shared_file')
+        sar.initialize_comms(rank, world_size, master_ip_address, backend, 
+                             shared_file=shard_file, barrier=barrier)
+    sar.start_comm_thread()
 
 
 def get_random_graph():
@@ -53,10 +63,41 @@ def load_partition_data(rank, graph_name, tmp_dir):
     """
     partition_file = os.path.join(tmp_dir, f'{graph_name}.json')
     partition_data = sar.load_dgl_partition_data(partition_file, rank, "cpu")
-    full_graph_manager = sar.construct_full_graph(partition_data).to('cpu')
     features = sar.suffix_key_lookup(partition_data.node_features, 'features')
     labels = sar.suffix_key_lookup(partition_data.node_features, 'labels')
+    full_graph_manager = sar.construct_full_graph(partition_data).to('cpu')
     return full_graph_manager, features, labels
+
+
+def load_partition_data_single_node(rank, graph_name, tmp_dir, lock):
+    """
+    Boilerplate code for loading partition data during SAR single node mode
+
+    :param rank: Rank of the current machine
+    :type rank: int
+    :param graph_name: Name of the partitioned graph
+    :type graph_name: str
+    :param tmp_dir: Path to the directory where partition data is located
+    :type tmp_dir: str
+    :param partition_data_manager: object for managing data during SAR single-node mode
+    :type partition_data_manager: PartitionDataManger
+    :param lock: lock is used to synchronize processes, so that we can be sure only one partition is\
+    loaded at the same time
+    :type lock: Lock
+    :returns: Tuple consisting of PartitionDataManager and GraphShardManager objects
+    """
+    partition_data_manager = sar.PartitionDataManager(rank, lock)
+    partition_file = os.path.join(tmp_dir, f'{graph_name}.json')
+    partition_data_manager.partition_data = sar.load_dgl_partition_data(
+        partition_file, rank, "cpu")
+    partition_data_manager.features = sar.suffix_key_lookup(
+        partition_data_manager.partition_data.node_features, 'features')
+    partition_data_manager.labels = sar.suffix_key_lookup(
+        partition_data_manager.partition_data.node_features, 'labels')
+    full_graph_manager = sar.construct_full_graph(
+        partition_data_manager.partition_data, partition_data_manager=partition_data_manager,
+        lock=lock).to('cpu')
+    return partition_data_manager, full_graph_manager
 
 
 def synchronize_processes():

--- a/tests/single_node/test_comm_sn.py
+++ b/tests/single_node/test_comm_sn.py
@@ -39,6 +39,7 @@ def test_sync_params_single_node(backend, world_size):
         except Exception as e:
             mp_dict["traceback"] = str(traceback.format_exc())
             mp_dict["exception"] = e
+            lock.release()
         
     lock = Lock()
     barrier = Barrier(world_size)
@@ -93,6 +94,7 @@ def test_gather_grads_single_node(world_size, backend):
         except Exception as e:
             mp_dict["traceback"] = str(traceback.format_exc())
             mp_dict["exception"] = e
+            lock.release()
     
     lock = Lock()
     barrier = Barrier(world_size)
@@ -130,6 +132,60 @@ def test_all_to_all_single_node_partition_data_manager(world_size, backend):
         except Exception as e: 
             mp_dict["traceback"] = str(traceback.format_exc())
             mp_dict["exception"] = e
+            lock.release()
+    
+    lock = Lock()
+    barrier = Barrier(world_size)
+    mp_dict = run_workers(all_to_all, world_size, backend=backend, lock=lock, barrier=barrier)
+    for rank in range(world_size):
+        for tensor in mp_dict[f"result_{rank}"]:
+            assert torch.all(torch.eq(tensor, torch.tensor([rank] * world_size)))
+            
+            
+@pytest.mark.parametrize("backend", ["ccl"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_all_to_all_single_node_graph_shard_manager(world_size, backend):
+    """
+    Checks whether all_to_all operation works as expected. Test is
+    designed is such a way, that after calling all_to_all, each worker
+    should receive a list of tensors with values equal to their rank
+    
+    It uses precall and callback functions from GraphShardManager object
+    """
+    def all_to_all(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        try:
+            lock = kwargs["lock"]
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_graph()
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            barrier.wait()
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"],
+                            barrier=kwargs["barrier"])
+            lock.acquire()
+            partition_data_manager, fgm = load_partition_data_single_node(rank, graph_name, tmp_dir,
+                                                                          kwargs["lock"])
+            num_labels = partition_data_manager.labels.max() + 1
+            sar.comm.all_reduce(num_labels, dist.ReduceOp.MAX, move_to_comm_device=True, 
+                        precall_func=partition_data_manager.precall_func, callback_func=partition_data_manager.callback_func)
+            partition_data_manager.features = sar.PointerTensor(partition_data_manager.features, 
+                                                                pointer=fgm.pointer_list, 
+                                                                linked=fgm.linked_list)
+            
+            send_tensors_list = [torch.tensor([x] * world_size) for x in range(world_size)]
+            recv_tensors_list = [torch.tensor([-1] * world_size) for _ in range(world_size)]
+            sar.comm.all_to_all(recv_tensors_list, send_tensors_list,
+                                precall_func=fgm.pause_process,
+                                callback_func=fgm.resume_process)
+            mp_dict[f"result_{rank}"] = recv_tensors_list
+            lock.release()
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+            lock.release()
     
     lock = Lock()
     barrier = Barrier(world_size)
@@ -175,6 +231,64 @@ def test_exchange_single_tensor_partition_data_manager(world_size, backend):
         except Exception as e: 
             mp_dict["traceback"] = str(traceback.format_exc())
             mp_dict["exception"] = e
+            lock.release()
+        
+    lock = Lock()
+    barrier = Barrier(world_size)
+    mp_dict = run_workers(exchange_single_tensor_single_node, world_size, backend=backend, lock=lock, barrier=barrier)
+
+
+@pytest.mark.parametrize("backend", ["ccl"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_exchange_single_tensor_graph_shard_manager(world_size, backend):
+    """
+    Checks whether exchange_single_tensor operation works as expected.  Test is
+    designed in such a way, that after calling exchange_single_tensor, worker
+    should receive a tensor with `world_size` elements of its rank value
+    
+    It uses precall and callback functions from GraphShardManager object
+    """
+    def exchange_single_tensor_single_node(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        try:
+            fail_flag = False
+            lock = kwargs["lock"]
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_graph()
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            barrier.wait()
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"])
+            lock.acquire()
+            partition_data_manager, fgm = load_partition_data_single_node(rank, graph_name, tmp_dir,
+                                                                          kwargs["lock"])
+            num_labels = partition_data_manager.labels.max() + 1
+            sar.comm.all_reduce(num_labels, dist.ReduceOp.MAX, move_to_comm_device=True, 
+                        precall_func=partition_data_manager.precall_func, callback_func=partition_data_manager.callback_func)
+            partition_data_manager.features = sar.PointerTensor(partition_data_manager.features, 
+                                                                pointer=fgm.pointer_list, 
+                                                                linked=fgm.linked_list)
+            send_idx = rank
+            recv_idx = rank
+            for _ in range(world_size):
+                send_tensor = torch.tensor([send_idx] * world_size)
+                recv_tensor = torch.tensor([-1] * world_size)
+                sar.comm.exchange_single_tensor(recv_idx, send_idx, recv_tensor, send_tensor,
+                                                precall_func=fgm.pause_process,
+                                                callback_func=fgm.resume_process)
+                if torch.all(torch.eq(recv_tensor, torch.tensor([rank] * world_size))).item() is False:
+                    fail_flag = True
+                    break
+                send_idx = (send_idx + 1) % world_size
+                recv_idx = (recv_idx - 1) % world_size
+            lock.release()
+            assert fail_flag == False
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+            lock.release()
         
     lock = Lock()
     barrier = Barrier(world_size)

--- a/tests/single_node/test_comm_sn.py
+++ b/tests/single_node/test_comm_sn.py
@@ -105,11 +105,13 @@ def test_gather_grads_single_node(world_size, backend):
 @pytest.mark.parametrize("backend", ["ccl"])
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 @sar_test
-def test_all_to_all_single_node(world_size, backend):
+def test_all_to_all_single_node_partition_data_manager(world_size, backend):
     """
     Checks whether all_to_all operation works as expected. Test is
     designed is such a way, that after calling all_to_all, each worker
     should receive a list of tensors with values equal to their rank
+    
+    It uses precall and callback functions from PartitionDataManager object
     """
     def all_to_all(mp_dict, rank, world_size, tmp_dir, **kwargs):
         try:
@@ -140,11 +142,13 @@ def test_all_to_all_single_node(world_size, backend):
 @pytest.mark.parametrize("backend", ["ccl"])
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 @sar_test
-def test_exchange_single_tensor(world_size, backend):
+def test_exchange_single_tensor_partition_data_manager(world_size, backend):
     """
     Checks whether exchange_single_tensor operation works as expected.  Test is
     designed in such a way, that after calling exchange_single_tensor, worker
     should receive a tensor with `world_size` elements of its rank value
+    
+    It uses precall and callback functions from PartitionDataManager object
     """
     def exchange_single_tensor_single_node(mp_dict, rank, world_size, tmp_dir, **kwargs):
         try:

--- a/tests/single_node/test_comm_sn.py
+++ b/tests/single_node/test_comm_sn.py
@@ -141,6 +141,11 @@ def test_all_to_all_single_node(world_size, backend):
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 @sar_test
 def test_exchange_single_tensor(world_size, backend):
+    """
+    Checks whether exchange_single_tensor operation works as expected.  Test is
+    designed in such a way, that after calling exchange_single_tensor, worker
+    should receive a tensor with `world_size` elements of its rank value
+    """
     def exchange_single_tensor_single_node(mp_dict, rank, world_size, tmp_dir, **kwargs):
         try:
             fail_flag = False

--- a/tests/single_node/test_comm_sn.py
+++ b/tests/single_node/test_comm_sn.py
@@ -1,0 +1,100 @@
+from multiprocessing import Lock, Barrier
+from multiprocessing_utils import *
+from copy import deepcopy
+import torch
+import torch.nn.functional as F
+import torch.distributed as dist
+import os
+import sar
+import dgl
+from models import GNNModel
+from base_utils import *
+
+
+@pytest.mark.parametrize("backend", ["ccl", "gloo"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_sync_params_single_node(backend, world_size):
+    """
+    Checks whether model's parameters are the same across all
+    workers after calling sync_params function. Parameters of worker 0
+    should be copied to all workers, so its parameters before and after
+    sync_params should be the same
+    """
+    def sync_params(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        try:
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"],
+                            barrier=kwargs["barrier"])
+            lock.acquire()
+            model = GNNModel(16, 4)
+            partition_data_manager = sar.PartitionDataManager(rank, lock)
+            if rank == 0:   
+                mp_dict[f"result_{rank}"] = deepcopy(model.state_dict())
+            sar.sync_params(model, precall_func=partition_data_manager.precall_func,
+                            callback_func=partition_data_manager.callback_func)
+            if rank != 0:
+                mp_dict[f"result_{rank}"] = model.state_dict()
+            lock.release()
+        except Exception as e:
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+        
+    lock = Lock()
+    barrier = Barrier(world_size)
+    mp_dict = run_workers(sync_params, world_size, backend=backend, lock=lock, barrier=barrier)
+    for rank in range(1, world_size):
+        for key in mp_dict[f"result_0"].keys():
+            assert torch.all(torch.eq(mp_dict[f"result_0"][key], mp_dict[f"result_{rank}"][key]))
+
+
+@pytest.mark.parametrize("backend", ["ccl"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_gather_grads_single_node(world_size, backend):
+    """
+    Checks whether parameter's gradients are the same across all
+    workers after calling gather_grads function 
+    """
+    def gather_grads(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        try:
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_graph()
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            barrier.wait()
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"],
+                            barrier=kwargs["barrier"])
+            lock.acquire()
+            partition_data_manager, fgm = load_partition_data_single_node(rank, graph_name, tmp_dir,
+                                                                          kwargs["lock"])
+            num_labels = partition_data_manager.labels.max() + 1
+            sar.comm.all_reduce(num_labels, dist.ReduceOp.MAX, move_to_comm_device=True, 
+                        precall_func=partition_data_manager.precall_func, callback_func=partition_data_manager.callback_func)
+            
+            model = GNNModel(partition_data_manager.features.shape[1], num_labels)
+            sar.sync_params(model, precall_func=partition_data_manager.precall_func,
+                            callback_func=partition_data_manager.callback_func)
+            
+            
+            partition_data_manager.features = sar.PointerTensor(partition_data_manager.features, 
+                                                                pointer=fgm.pointer_list, 
+                                                                linked=fgm.linked_list)
+            sar_logits = model(fgm, partition_data_manager.features)
+            sar_loss = F.cross_entropy(sar_logits, partition_data_manager.labels)
+            sar_loss.backward()
+            sar.gather_grads(model, precall_func=fgm.pause_process,
+                             callback_func=fgm.resume_process)
+            mp_dict[f"result_{rank}"] = [torch.tensor(x.grad) for x in model.parameters()]
+            lock.release()
+        except Exception as e:
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+    
+    lock = Lock()
+    barrier = Barrier(world_size)
+    mp_dict = run_workers(gather_grads, world_size, backend=backend, lock=lock, barrier=barrier)
+    for rank in range(1, world_size):
+        for i in range(len(mp_dict["result_0"])):
+            assert torch.all(torch.eq(mp_dict["result_0"][i], mp_dict[f"result_{rank}"][i]))

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -54,6 +54,7 @@ def test_gather_grads(world_size, backend):
         from models import GNNModel
         from base_utils import initialize_worker, get_random_graph, synchronize_processes,\
             load_partition_data
+        import torch.distributed as dist
         try:
             initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"])
             graph_name = 'dummy_graph'
@@ -64,7 +65,9 @@ def test_gather_grads(world_size, backend):
                                         balance_edges=True)
             synchronize_processes()
             fgm, feat, labels = load_partition_data(rank, graph_name, tmp_dir)
-            model = GNNModel(feat.shape[1], labels.max()+1)
+            num_labels = labels.max() + 1
+            sar.comm.all_reduce(num_labels, dist.ReduceOp.MAX, move_to_comm_device=True)
+            model = GNNModel(feat.shape[1], num_labels)
             sar.sync_params(model)
             sar_logits = model(fgm, feat)
             sar_loss = F.cross_entropy(sar_logits, labels)

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -117,6 +117,11 @@ def test_all_to_all(world_size, backend):
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 @sar_test
 def test_exchange_single_tensor(world_size, backend):
+    """
+    Checks whether exchange_single_tensor operation works as expected.  Test is
+    designed in such a way, that after calling exchange_single_tensor, worker
+    should receive a tensor with `world_size` elements of its rank value
+    """
     def exchange_single_tensor(mp_dict, rank, world_size, tmp_dir, **kwargs):
         import torch
         import sar


### PR DESCRIPTION
- Added pytests for some functions in comm.py (functions that are tested in IntelLabs SAR repo - sync_params, gather_grads, all_to_all, exchange_single_tensor)
- Fixed one issue with synchronizing labels in original SAR pytests

This PR needs to be review/merged after #3 (because it includes changes to PartitionDataManager that were introduced in #3)

TODO: enable single node for `gloo` backend path. Currently. tests that use all_to_all or exchange_single_tensor are runned only for `ccl` backend