### PR TITLE
Removing saved files from disk

### DIFF
--- a/examples/train_homogeneous_graph_basic_single-node.py
+++ b/examples/train_homogeneous_graph_basic_single-node.py
@@ -257,6 +257,9 @@ def run(args, rank, lock, barrier):
         
         full_graph_manager.print_metrics()
         
+        # Clean files saved on disk during epoch
+        partition_data_manager.remove_files()
+        
     lock.release()
 
 if __name__ == '__main__':

--- a/sar/core/graphshard.py
+++ b/sar/core/graphshard.py
@@ -359,11 +359,17 @@ class GraphShardManager:
                 del self.edata
             if hasattr(self, 'graph_shards') and self.partition_data_manager.save_tensor(self.graph_shards, 'graph_shards'):
                 del self.graph_shards
-            if hasattr(self, 'input_nodes') and self.partition_data_manager.save_tensor(self.input_nodes, 'input_nodes'):
+            if hasattr(self, 'input_nodes') and \
+                    self.partition_data_manager.does_file_exist("input_nodes.pt") is False and \
+                    self.partition_data_manager.save_tensor(self.input_nodes, 'input_nodes'):
                 del self.input_nodes
-            if hasattr(self, 'seeds') and self.partition_data_manager.save_tensor(self.seeds, 'seeds'):
+            if hasattr(self, 'seeds') and \
+                    self.partition_data_manager.does_file_exist("seeds.pt") is False and \
+                    self.partition_data_manager.save_tensor(self.seeds, 'seeds'):
                 del self.seeds
-            if hasattr(self, 'indices_required_from_me') and self.partition_data_manager.save_tensor(self.indices_required_from_me, 'indicies_required_from_me'):
+            if hasattr(self, 'indices_required_from_me') and \
+                    self.partition_data_manager.does_file_exist("indicies_required_from_me.pt") is False and \
+                    self.partition_data_manager.save_tensor(self.indices_required_from_me, 'indicies_required_from_me'):
                 del self.indices_required_from_me
             
             for idx, tens in enumerate(self.pointer_list):
@@ -378,7 +384,7 @@ class GraphShardManager:
                     sys.stdin = _stdin
                 '''
                 try:
-                    fname = "rank{}_tensor{}.pt".format(rank(), idx)
+                    fname = "rank{}_tensor{}".format(rank(), idx)
                     if tens.requires_grad:
                         tens_d = tens.detach()
                         self.partition_data_manager.save_tensor(tens_d, fname)
@@ -455,7 +461,7 @@ class GraphShardManager:
             except Exception as e: 
                 logger.debug("_resume_process Exception: {}".format(e))
             for idx, tens in enumerate(self.pointer_list):
-                fname = "rank{}_tensor{}.pt".format(rank(), idx)
+                fname = "rank{}_tensor{}".format(rank(), idx)
                 try:
                     tmp_tens = self.partition_data_manager.load_tensor(fname)
                     if tens.requires_grad:


### PR DESCRIPTION
PR changes:

- Added `remove_files` function in PartitionDataManager, which deletes directory for its partition.
	- It is called on PartitionDataManager object initialization, in case files weren't deleted automatically (Possible scenario - user stopped program during an epoch, thus files were not deleted)
	- It is called in the example script at the end of each epoch

- Since `masks`, `labels` and `partition_data` data don't change during the training, from now PartitionDataManager saves it to disk only if it hasn't been already saved. (That's another reason, why `remove_files` function should be called on PartitionDataManager object initialization - saved files could be associated with a different dataset.) The same goes for `input_nodes`, `seeds` and `indices_required_from_me` data in GraphShardManager. This data is saved only if it is not already on disk.

- Saved tensor had double extension ".pt" - for example "rank1_tensor0.pt.pt". Repeated extension was removed