### PR TITLE
sar.start_comm_thread - removed

### DIFF
--- a/examples/SIGN/train_sign_with_sar.py
+++ b/examples/SIGN/train_sign_with_sar.py
@@ -203,7 +203,6 @@ def main(args):
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
 
     data = prepare_data(device, args)
     (

--- a/examples/correct_and_smooth.py
+++ b/examples/correct_and_smooth.py
@@ -369,7 +369,6 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_dist_appnp_with_sar.py
+++ b/examples/train_dist_appnp_with_sar.py
@@ -134,7 +134,6 @@ def main():
                          args.world_size,
                          master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
     
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_distdgl_with_sar_inference.py
+++ b/examples/train_distdgl_with_sar_inference.py
@@ -375,7 +375,6 @@ def main(args):
                          master_ip_address,
                          args.backend
                          )
-    sar.start_comm_thread()
 
     print(socket.gethostname(), "rank:", g.rank())
 

--- a/examples/train_heterogeneous_graph.py
+++ b/examples/train_heterogeneous_graph.py
@@ -116,7 +116,6 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_homogeneous_graph_advanced.py
+++ b/examples/train_homogeneous_graph_advanced.py
@@ -276,7 +276,6 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend, comm_device)
-    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_homogeneous_graph_basic.py
+++ b/examples/train_homogeneous_graph_basic.py
@@ -113,7 +113,6 @@ def main():
                          args.world_size,
                          master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
     
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/examples/train_homogeneous_graph_basic_single-node.py
+++ b/examples/train_homogeneous_graph_basic_single-node.py
@@ -138,9 +138,6 @@ def run(args, rank, lock, barrier):
                          args.backend, shared_file=args.shared_file, barrier=barrier)
 
     lock.acquire()
-    print("Node {} Lock Acquired".format(rank))
-
-    sar.start_comm_thread()
     
     # Instantiate PartitionDataManager for managing data saving and loading from disk
     partition_data_manager = sar.PartitionDataManager(rank, lock)

--- a/examples/train_homogeneous_sampling_basic.py
+++ b/examples/train_homogeneous_sampling_basic.py
@@ -152,7 +152,6 @@ def main():
     sar.initialize_comms(args.rank,
                          args.world_size, master_ip_address,
                          args.backend)
-    sar.start_comm_thread()
 
     # Load DGL partition data
     partition_data = sar.load_dgl_partition_data(

--- a/sar/__init__.py
+++ b/sar/__init__.py
@@ -27,7 +27,7 @@ from . import core
 from .comm import initialize_comms, rank, world_size, comm_device,\
     nfs_ip_init, sync_params, gather_grads
 from .core import GraphShardManager, message_has_parameters, DistributedBlock,\
-    DistNeighborSampler, DataLoader, start_comm_thread
+    DistNeighborSampler, DataLoader
 from .construct_shard_manager import construct_mfgs, construct_full_graph, convert_dist_graph
 from .data_loading import load_dgl_partition_data, suffix_key_lookup, PartitionDataManager
 from .distributed_bn import DistributedBN1D

--- a/sar/comm.py
+++ b/sar/comm.py
@@ -580,17 +580,25 @@ class CommThread:
     '''
 
     def __init__(self) -> None:
+        self.is_initialized = False
+        
+    def initialize(self):
+        self.is_initialized = True
+        
         self.task_queue: queue.Queue = queue.Queue()
         self.result_queue: queue.Queue = queue.Queue()
 
         _comm_thread = threading.Thread(target=self._fetch_tasks)
         _comm_thread.daemon = True
         _comm_thread.start()
-
+        
     def submit_task(self, task_id: str, task: Callable[[], Any]) -> None:
         '''
         Submit a task in the form of a  callable with no arguments.
         '''
+        
+        if self.is_initialized == False:
+            self.initialize()
         logger.debug('task submitted %s', task_id)
         self.task_queue.put((task_id, task))
 
@@ -599,6 +607,8 @@ class CommThread:
         Reads the result queue and returns the result of the oldest
         executed task whose reult has not been read yet
         '''
+        if self.is_initialized == False:
+            self.initialize()
         t_1 = time.time()
         res = self.result_queue.get(block=block)
         logger.debug('task result retreival done in %s ', time.time() - t_1)
@@ -610,6 +620,6 @@ class CommThread:
             result = task()
             if result is not None:
                 self.result_queue.put(result)
+                
 
-
-#comm_thread = CommThread()
+comm_thread = CommThread()

--- a/sar/core/__init__.py
+++ b/sar/core/__init__.py
@@ -22,7 +22,7 @@
 Modules for sharded data representation and management
 '''
 from .graphshard import GraphShard, GraphShardManager
-from .sar_aggregation import message_has_parameters, start_comm_thread
+from .sar_aggregation import message_has_parameters
 from .full_partition_block import DistributedBlock
 from .sampling import DistNeighborSampler, DataLoader
 

--- a/sar/core/sar_aggregation.py
+++ b/sar/core/sar_aggregation.py
@@ -33,7 +33,7 @@ import dgl.function as fn  # type: ignore
 from torch import Tensor
 
 from ..config import Config
-from ..comm import exchange_single_tensor,  rank,  CommThread, world_size
+from ..comm import exchange_single_tensor,  rank, comm_thread, world_size
 from ..common_tuples import AggregationData, TensorPlace, ShardInfo
 
 if TYPE_CHECKING:
@@ -42,10 +42,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 logger.setLevel(logging.DEBUG)
-
-def start_comm_thread():
-    global comm_thread
-    comm_thread = CommThread()
 
 
 def message_has_parameters(param_foo: Callable[[Any], Tuple[Tensor, ...]]):

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -32,7 +32,6 @@ def initialize_worker(rank, world_size, tmp_dir, backend="ccl", barrier=None):
         shard_file = os.path.join(tmp_dir, 'shared_file')
         sar.initialize_comms(rank, world_size, master_ip_address, backend, 
                              shared_file=shard_file, barrier=barrier)
-    sar.start_comm_thread()
 
 
 def get_random_graph():

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -46,7 +46,6 @@ def sar_process(mp_dict, rank, world_size, tmp_dir):
                              world_size,
                              master_ip_address,
                              'ccl')
-        sar.start_comm_thread()
 
         partition_data = sar.load_dgl_partition_data(
             part_file, rank, 'cpu')


### PR DESCRIPTION
Removed necessity to call sar.start_comm_thread before training. CommThread initializes during a first call to its function i.e. `submit_task` or `get_result`, and not after calling sar.start_comm_thread.

Please merge/review after #10 